### PR TITLE
Improve the entity kinds order used in BuiltinEntityParser

### DIFF
--- a/platforms/snips-nlu-ontology-python/.gitignore
+++ b/platforms/snips-nlu-ontology-python/.gitignore
@@ -1,4 +1,5 @@
 venv/
+venv2/
 venv3/
 venv34/
 venv35/

--- a/platforms/snips-nlu-ontology-python/snips_nlu_ontology/__init__.py
+++ b/platforms/snips-nlu-ontology-python/snips_nlu_ontology/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from snips_nlu_ontology.builtin_entities import (
     BuiltinEntityParser, get_all_languages, get_all_builtin_entities,
-    get_supported_entities, get_ontology_version)
+    get_supported_entities, get_ontology_version, get_builtin_entity_examples)

--- a/platforms/snips-nlu-ontology-python/snips_nlu_ontology/tests/test_builtin_entity_parser.py
+++ b/platforms/snips-nlu-ontology-python/snips_nlu_ontology/tests/test_builtin_entity_parser.py
@@ -32,7 +32,7 @@ class TestBuiltinEntityParser(unittest.TestCase):
     def test_should_parse_with_scope(self):
         # Given
         parser = BuiltinEntityParser("en")
-        scope = ["snips/temperature", "snips/number"]
+        scope = ["snips/duration", "snips/temperature"]
 
         # When
         res = parser.parse("Raise to sixty two", scope)

--- a/snips-nlu-ontology-parsers/src/rustling_converters.rs
+++ b/snips-nlu-ontology-parsers/src/rustling_converters.rs
@@ -208,6 +208,20 @@ impl<'a> FromRustling<&'a Output> for BuiltinEntityKind {
     }
 }
 
+impl<'a> FromRustling<&'a OutputKind> for BuiltinEntityKind {
+    fn from_rustling(v: &OutputKind) -> Self {
+        match *v {
+            OutputKind::AmountOfMoney => BuiltinEntityKind::AmountOfMoney,
+            OutputKind::Duration => BuiltinEntityKind::Duration,
+            OutputKind::Number => BuiltinEntityKind::Number,
+            OutputKind::Ordinal => BuiltinEntityKind::Ordinal,
+            OutputKind::Temperature => BuiltinEntityKind::Temperature,
+            OutputKind::Time => BuiltinEntityKind::Time,
+            OutputKind::Percentage => BuiltinEntityKind::Percentage,
+        }
+    }
+}
+
 impl<'a> FromRustling<&'a BuiltinEntityKind> for OutputKind {
     fn from_rustling(v: &BuiltinEntityKind) -> Self {
         match *v {

--- a/snips-nlu-ontology/src/builtin_entity.rs
+++ b/snips-nlu-ontology/src/builtin_entity.rs
@@ -472,6 +472,16 @@ impl BuiltinEntityKind {
     }
 }
 
+impl BuiltinEntityKind {
+    pub fn supported_entity_kinds(language: Language) -> Vec<BuiltinEntityKind> {
+        Self::all()
+            .to_vec()
+            .into_iter()
+            .filter(|e| e.supported_languages().contains(&language))
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Description**
This PR improves how the builtin entity scope, used when calling rustling, is built. More precisely, the `parse` method of rustling is no longer used in the `BuiltinEntityParser` when the scope is `None`. Instead, `parse_with_kind_order` is called with a scope containing all the supported builtin entities for the specified language.

This results in a better separation between the `BuiltinEntityParser` (snips-nlu-ontology) and Rustling.