### PR TITLE
 Replace HashMap cache with LruCache for BuiltinEntityParser

### DIFF
--- a/snips-nlu-ontology-doc/build.rs
+++ b/snips-nlu-ontology-doc/build.rs
@@ -28,6 +28,11 @@ fn add_header(readme: &mut String) {
     );
     readme.push_str("   :target: https://travis-ci.org/snipsco/snips-nlu-ontology\n");
     readme.push_str("\n");
+    readme.push_str(
+        ".. image:: https://ci.appveyor.com/api/projects/status/github/snipsco/snips-nlu-ontology?branch=develop&svg=true\n",
+    );
+    readme.push_str("   :target: https://ci.appveyor.com/project/snipsco/snips-nlu-ontology\n");
+    readme.push_str("\n");
 
     readme.push_str("Ontology of the Snips NLU library API which describes supported languages and builtin entities.\n");
     readme.push_str("Please refer to `this page <platforms/snips-nlu-ontology-python>`_ for the python wrapper.\n");

--- a/snips-nlu-ontology-parsers/Cargo.toml
+++ b/snips-nlu-ontology-parsers/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Kevin Lefevre <kevin.lefevre@snips.ai>"]
 itertools = "0.7"
 lazy_static = "1.0"
 maplit = "1.0"
+lru-cache = "0.1.1"
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.0" }
 regex = "0.2"
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.17.0" }

--- a/snips-nlu-ontology-parsers/src/lib.rs
+++ b/snips-nlu-ontology-parsers/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
+extern crate lru_cache;
 #[macro_use]
 extern crate maplit;
 extern crate regex;


### PR DESCRIPTION
**Description**
The `BuiltinEntityParser`'s cache was implemented with a naive `HashMap` that was not being emptied. This PR replaces it with an `LruCache` reducing the memory usage over time.