### PR TITLE
Remove builtin entity caching

### DIFF
--- a/snips-nlu-ontology-parsers/Cargo.toml
+++ b/snips-nlu-ontology-parsers/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Kevin Lefevre <kevin.lefevre@snips.ai>"]
 itertools = "0.7"
 lazy_static = "1.0"
 maplit = "1.0"
-lru-cache = "0.1.1"
 snips-nlu-utils = { git = "https://github.com/snipsco/snips-nlu-utils", tag = "0.6.0" }
 regex = "0.2"
 rustling-ontology = { git = "https://github.com/snipsco/rustling-ontology", tag = "0.17.0" }

--- a/snips-nlu-ontology-parsers/src/lib.rs
+++ b/snips-nlu-ontology-parsers/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
-extern crate lru_cache;
 #[macro_use]
 extern crate maplit;
 extern crate regex;


### PR DESCRIPTION
**Description**
This PR removes the LRU cache previously introduced.
The idea is to let the client code handle the caching strategy to avoid unexpected caching behavior, especially with datetimes.