### PR TITLE
Fix issue with BuiltinEntityParser python destructor

### DIFF
--- a/platforms/snips-nlu-ontology-python/snips_nlu_ontology/builtin_entities.py
+++ b/platforms/snips-nlu-ontology-python/snips_nlu_ontology/builtin_entities.py
@@ -125,7 +125,7 @@ class BuiltinEntityParser(object):
                               "intent parser. See stderr.")
 
     def __del__(self):
-        if hasattr(self, '_parser'):
+        if lib is not None and hasattr(self, '_parser'):
             lib.snips_nlu_ontology_destroy_builtin_entity_parser(self._parser)
 
     def parse(self, text, scope=None):


### PR DESCRIPTION
**Description**
This PR fixes a crash that occurs when a `BuiltinEntityParser` object gets destroyed after the global variable `lib` (dynamic C lib)  is destroyed.