### PR TITLE
Update fields

### DIFF
--- a/ffi/ffi-macros/src/ontology.rs
+++ b/ffi/ffi-macros/src/ontology.rs
@@ -46,7 +46,7 @@ pub struct CIntentClassifierResult {
     /// Name of the intent detected
     pub intent_name: *const libc::c_char,
     /// Between 0 and 1
-    pub probability: libc::c_float,
+    pub confidence_score: libc::c_float,
 }
 
 impl From<IntentClassifierResult> for CIntentClassifierResult {
@@ -57,7 +57,7 @@ impl From<IntentClassifierResult> for CIntentClassifierResult {
             .unwrap_or_else(|| null());
         Self {
             intent_name,
-            probability: input.probability,
+            confidence_score: input.confidence_score,
         }
     }
 }

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/Ontology.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/Ontology.kt
@@ -138,11 +138,10 @@ sealed class SlotValue(val type: Type) {
     data class MusicTrackValue @ParcelConstructor constructor(@ParcelProperty("value") val value: String) : SlotValue(MUSICTRACK)
 }
 
-
 @Parcel(BEAN)
 data class IntentClassifierResult @ParcelConstructor constructor(
         @ParcelProperty("intentName") val intentName: String?,
-        @ParcelProperty("probability") val probability: Float)
+        @ParcelProperty("confidenceScore") val confidenceScore: Float)
 
 @Parcel(BEAN)
 data class IntentParserResult @ParcelConstructor constructor(

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
@@ -55,16 +55,15 @@ class CIntentParserResult(p: Pointer) : Structure(p), Structure.ByReference {
 
 class CIntentClassifierResult : Structure(), Structure.ByReference {
     @JvmField var intent_name: Pointer? = null
-    @JvmField var probability: Float? = null
+    @JvmField var confidence_score: Float? = null
 
-    override fun getFieldOrder() = listOf("intent_name", "probability")
+    override fun getFieldOrder() = listOf("intent_name", "confidence_score")
 
     fun toIntentClassifierResult() = IntentClassifierResult(intentName = intent_name?.readString(),
-                                                            probability = probability!!)
+                                                            confidenceScore = confidence_score!!)
 }
 
 class CSlots : Structure(), Structure.ByReference {
-
     @JvmField var slots: Pointer? = null
     @JvmField var size: Int = -1
 

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -11,7 +11,7 @@ pub struct IntentParserResult {
 #[serde(rename_all = "camelCase")]
 pub struct IntentClassifierResult {
     pub intent_name: Option<String>,
-    pub probability: f32,
+    pub confidence_score: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -22,6 +22,7 @@ pub struct Slot {
     pub range: Range<usize>,
     pub entity: String,
     pub slot_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub confidence_score: Option<f32>,
 }
 


### PR DESCRIPTION
This aligns ontology with Hermes ontology as required by backend + skip serializing slot confidence score if the value is none (console use case).