### PR TITLE
Release 0.64.0 - 2019-02-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.64.0] - 2019-02-27
+### Added
+- Support for Portuguese (PT-PT and PT-BR)
+
+### Changed
+- Rename the `probability` output field to `confidence_score` in the intent
+- When we serialize the slots to JSON the `confidenceScore` field is dropped if null
+
 ## [0.63.2] - 2019-02-06
 ### Changed
 - Kotlin wrapper: update kotlin to 1.3.11
@@ -136,6 +144,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated Rustling ontology to `0.16.4`
 
+[0.64.0]: https://github.com/snipsco/snips-nlu-ontology/compare/0.63.2...0.64.0
 [0.63.2]: https://github.com/snipsco/snips-nlu-ontology/compare/0.63.1...0.63.2
 [0.63.1]: https://github.com/snipsco/snips-nlu-ontology/compare/0.63.0...0.63.1
 [0.63.0]: https://github.com/snipsco/snips-nlu-ontology/compare/0.62.0...0.63.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology"
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 authors = [
     "Adrien Ball <adrien.ball@snips.ai>",
     "Thibaut Lorrain <thibaut.lorrain@snips.ai>",

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-doc"
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 authors = ["Adrien Ball <adrien.ball@snips.ai>"]
 edition = "2018"
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-ffi"
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 authors = ["Kevin Lefevre <kevin.lefevre@snips.ai>"]
 edition = "2018"
 

--- a/ffi/ffi-macros/Cargo.toml
+++ b/ffi/ffi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-ffi-macros"
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 authors = [
     "Kevin Lefevre <kevin.lefevre@snips.ai>",
     "Thibaut Lorrain <thibaut.lorrain@snips.ai>",

--- a/platforms/kotlin/build.gradle
+++ b/platforms/kotlin/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 group = "ai.snips"
 
 

--- a/platforms/kotlin/snips-nlu-ontology-export/build.gradle
+++ b/platforms/kotlin/snips-nlu-ontology-export/build.gradle
@@ -1,4 +1,4 @@
-version = "0.64.0-SNAPSHOT"
+version = "0.64.0"
 group = "ai.snips"
 
 


### PR DESCRIPTION
## [0.64.0] - 2019-02-27
### Added
- Support for Portuguese (PT-PT and PT-BR)

### Changed
- Rename the `probability` output field to `confidence_score` in the intent
- When we serialize the slots to JSON the `confidenceScore` field is dropped if null