### PR TITLE
Update ffi and kotlin bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,73 +39,87 @@ Supported languages
 Supported builtin entities
 --------------------------
 
-+---------------+---------------------+---------------------+---------------------+
-| Entity        | Identifier          | Category            | Supported languages |
-+===============+=====================+=====================+=====================+
-| AmountOfMoney | snips/amountOfMoney | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
-| Time          | snips/datetime      | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
-| Duration      | snips/duration      | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
-| MusicAlbum    | snips/musicAlbum    | `Gazetteer Entity`_ | | English           |
-|               |                     |                     | | French            |
-+---------------+---------------------+---------------------+---------------------+
-| MusicArtist   | snips/musicArtist   | `Gazetteer Entity`_ | | English           |
-|               |                     |                     | | French            |
-+---------------+---------------------+---------------------+---------------------+
-| MusicTrack    | snips/musicTrack    | `Gazetteer Entity`_ | | English           |
-|               |                     |                     | | French            |
-+---------------+---------------------+---------------------+---------------------+
-| Number        | snips/number        | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
-| Ordinal       | snips/ordinal       | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
-| Percentage    | snips/percentage    | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-+---------------+---------------------+---------------------+---------------------+
-| Temperature   | snips/temperature   | `Grammar Entity`_   | | German            |
-|               |                     |                     | | English           |
-|               |                     |                     | | Spanish           |
-|               |                     |                     | | French            |
-|               |                     |                     | | Italian           |
-|               |                     |                     | | Japanese          |
-|               |                     |                     | | Korean            |
-+---------------+---------------------+---------------------+---------------------+
++---------------+---------------------+---------------------+-----------------------+
+| Entity        | Identifier          | Category            | Supported languages   |
++===============+=====================+=====================+=======================+
+| AmountOfMoney | snips/amountOfMoney | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| Time          | snips/datetime      | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| Duration      | snips/duration      | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| MusicAlbum    | snips/musicAlbum    | `Gazetteer Entity`_ | | English             |
+|               |                     |                     | | French              |
++---------------+---------------------+---------------------+-----------------------+
+| MusicArtist   | snips/musicArtist   | `Gazetteer Entity`_ | | English             |
+|               |                     |                     | | French              |
++---------------+---------------------+---------------------+-----------------------+
+| MusicTrack    | snips/musicTrack    | `Gazetteer Entity`_ | | English             |
+|               |                     |                     | | French              |
++---------------+---------------------+---------------------+-----------------------+
+| Number        | snips/number        | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| Ordinal       | snips/ordinal       | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| Percentage    | snips/percentage    | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
+| Temperature   | snips/temperature   | `Grammar Entity`_   | | German              |
+|               |                     |                     | | English             |
+|               |                     |                     | | Spanish             |
+|               |                     |                     | | French              |
+|               |                     |                     | | Italian             |
+|               |                     |                     | | Japanese            |
+|               |                     |                     | | Korean              |
+|               |                     |                     | | Portuguese - Brazil |
+|               |                     |                     | | Portuguese - Europe |
++---------------+---------------------+---------------------+-----------------------+
 
 Grammar Entity
 --------------

--- a/ffi/ffi-macros/src/ontology.rs
+++ b/ffi/ffi-macros/src/ontology.rs
@@ -71,14 +71,14 @@ impl Drop for CIntentClassifierResult {
 /// Wrapper around a list of IntentClassifierResult
 #[repr(C)]
 #[derive(Debug)]
-pub struct CIntentClassifierResultList {
+pub struct CIntentClassifierResultArray {
     /// Pointer to the first result of the list
     pub intent_classifier_results: *const CIntentClassifierResult,
     /// Number of results in the list
     pub size: libc::int32_t,
 }
 
-impl From<Vec<IntentClassifierResult>> for CIntentClassifierResultList {
+impl From<Vec<IntentClassifierResult>> for CIntentClassifierResultArray {
     fn from(input: Vec<IntentClassifierResult>) -> Self {
         Self {
             size: input.len() as libc::int32_t,
@@ -93,7 +93,7 @@ impl From<Vec<IntentClassifierResult>> for CIntentClassifierResultList {
     }
 }
 
-impl Drop for CIntentClassifierResultList {
+impl Drop for CIntentClassifierResultArray {
     fn drop(&mut self) {
         let _ = unsafe {
             Box::from_raw(slice::from_raw_parts_mut(

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,3 +1,6 @@
+extern crate ffi_utils;
+extern crate snips_nlu_ontology_ffi_macros;
+
 use ffi_utils::{generate_error_handling, wrap};
 use snips_nlu_ontology_ffi_macros::export_nlu_ontology_c_symbols;
 

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
@@ -35,13 +35,14 @@ fun Float?.readFloat(): Float? = if (this!! < 0) null else this!!
 fun CSlotValue?.readSlotValue(): SlotValue = this!!.toSlotValue()
 
 class CIntentParserResult(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var input: Pointer? = null
     @JvmField var intent: CIntentClassifierResult? = null
     @JvmField var slots: CSlots? = null
+
+    init {
+        read()
+    }
 
     override fun getFieldOrder() = listOf("input",
                                           "intent",
@@ -53,9 +54,16 @@ class CIntentParserResult(p: Pointer) : Structure(p), Structure.ByReference {
 
 }
 
-class CIntentClassifierResult : Structure(), Structure.ByReference {
+class CIntentClassifierResult(p: Pointer?) : Structure(p), Structure.ByReference {
+
     @JvmField var intent_name: Pointer? = null
     @JvmField var confidence_score: Float? = null
+
+    init {
+        read()
+    }
+
+    constructor(): this(null)
 
     override fun getFieldOrder() = listOf("intent_name", "confidence_score")
 
@@ -63,9 +71,37 @@ class CIntentClassifierResult : Structure(), Structure.ByReference {
                                                             confidenceScore = confidence_score!!)
 }
 
-class CSlots : Structure(), Structure.ByReference {
+class CIntentClassifierResultList(p: Pointer?) : Structure(p), Structure.ByReference {
+
+    @JvmField var intent_classifier_results: Pointer? = null
+    @JvmField var size: Int = -1
+
+    init {
+        read()
+    }
+
+    constructor(): this(null)
+
+    override fun getFieldOrder() = listOf("intent_classifier_results", "size")
+
+    fun toIntentClassifierResultList(): List<IntentClassifierResult> =
+            if (size > 0)
+                CIntentClassifierResult(intent_classifier_results!!)
+                        .toArray(size)
+                        .map { (it as CIntentClassifierResult).toIntentClassifierResult() }
+            else listOf<IntentClassifierResult>()
+}
+
+class CSlots(p: Pointer?) : Structure(p), Structure.ByReference {
+
     @JvmField var slots: Pointer? = null
     @JvmField var size: Int = -1
+
+    init {
+        read()
+    }
+
+    constructor(): this(null)
 
     override fun getFieldOrder() = listOf("slots", "size")
 
@@ -149,14 +185,17 @@ class CSlotValue : Structure(), Structure.ByValue {
 }
 
 class CInstantTimeValue(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var value: Pointer? = null
     @JvmField var grain: Int? = null
     @JvmField var precision: Int? = null
+
+    init {
+        read()
+    }
+
     override fun getFieldOrder() = listOf("value", "grain", "precision")
+
     fun toInstantTimeValue(): InstantTimeValue {
         return InstantTimeValue(value = value.readString(),
                                 grain = grain.readGrain(),
@@ -166,24 +205,28 @@ class CInstantTimeValue(p: Pointer) : Structure(p), Structure.ByReference {
 }
 
 class CTimeIntervalValue(p: Pointer) : Structure(p), Structure.ByReference {
+
+    @JvmField var from: Pointer? = null
+    @JvmField var to: Pointer? = null
+
     init {
         read()
     }
 
-    @JvmField var from: Pointer? = null
-    @JvmField var to: Pointer? = null
     override fun getFieldOrder() = listOf("from", "to")
+
     fun toTimeIntervalValue() = TimeIntervalValue(from = from?.readString(), to = to?.readString())
 }
 
 class CAmountOfMoneyValue(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var value: Float? = null
     @JvmField var precision: Int? = null
     @JvmField var unit: Pointer? = null
+
+    init {
+        read()
+    }
 
     override fun getFieldOrder() = listOf("unit", "value", "precision")
 
@@ -193,12 +236,13 @@ class CAmountOfMoneyValue(p: Pointer) : Structure(p), Structure.ByReference {
 }
 
 class CTemperatureValue(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var value: Float? = null
     @JvmField var unit: Pointer? = null
+
+    init {
+        read()
+    }
 
     override fun getFieldOrder() = listOf("unit", "value")
 
@@ -208,9 +252,6 @@ class CTemperatureValue(p: Pointer) : Structure(p), Structure.ByReference {
 }
 
 class CDurationValue(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var years: Long? = null
     @JvmField var quarters: Long? = null
@@ -221,6 +262,10 @@ class CDurationValue(p: Pointer) : Structure(p), Structure.ByReference {
     @JvmField var minutes: Long? = null
     @JvmField var seconds: Long? = null
     @JvmField var precision: Int? = null
+
+    init {
+        read()
+    }
 
     override fun getFieldOrder() = listOf("years",
                                           "quarters",
@@ -245,9 +290,6 @@ class CDurationValue(p: Pointer) : Structure(p), Structure.ByReference {
 
 
 class CSlot(p: Pointer) : Structure(p), Structure.ByReference {
-    init {
-        read()
-    }
 
     @JvmField var raw_value: Pointer? = null
     @JvmField var value: CSlotValue? = null
@@ -256,6 +298,10 @@ class CSlot(p: Pointer) : Structure(p), Structure.ByReference {
     @JvmField var entity: Pointer? = null
     @JvmField var slot_name: Pointer? = null
     @JvmField var confidence_score: Float? = null
+
+    init {
+        read()
+    }
 
     override fun getFieldOrder() = listOf("value",
                                           "raw_value",

--- a/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
+++ b/platforms/kotlin/src/main/kotlin/ai/snips/nlu/ontology/ffi/COntology.kt
@@ -71,7 +71,7 @@ class CIntentClassifierResult(p: Pointer?) : Structure(p), Structure.ByReference
                                                             confidenceScore = confidence_score!!)
 }
 
-class CIntentClassifierResultList(p: Pointer?) : Structure(p), Structure.ByReference {
+class CIntentClassifierResultArray(p: Pointer?) : Structure(p), Structure.ByReference {
 
     @JvmField var intent_classifier_results: Pointer? = null
     @JvmField var size: Int = -1

--- a/src/language.rs
+++ b/src/language.rs
@@ -3,6 +3,7 @@ use failure::bail;
 macro_rules! language_enum {
     ([$($language:ident),*]) => {
         #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Hash, Eq)]
+        #[allow(non_camel_case_types)]
         pub enum Language {
             $( $language, )*
         }


### PR DESCRIPTION
**Description**
- Add a `CIntentClassifierResultList` objet to the ffi, which is used in the [`get_intents`](https://github.com/snipsco/snips-nlu-rs/blob/develop/src/nlu_engine.rs#L185) API of `snips-nlu-rs`
- kotlin wrapper: allow to pass a `Pointer` when creating a `CIntentClassifierResult` or `CSlots` object