### PR TITLE
Check for git changes after build step

### DIFF
--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -9,6 +9,13 @@ fi
 export PATH="$HOME/.cargo/bin:$PATH"
 
 cargo build --all
+
+if [[ `git status --porcelain` ]]; then
+  echo "The build step produced some changes that are not versioned"
+  echo git status
+  exit 1
+fi
+
 cargo test --all
 
 if [[ "$KOTLIN_TESTS" == "true" ]]; then

--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -12,7 +12,7 @@ cargo build --all
 
 if [[ `git status --porcelain` ]]; then
   echo "The build step produced some changes that are not versioned"
-  echo git status
+  git status
   exit 1
 fi
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,6 @@ Supported builtin entities
 |               |                     |                     | | French              |
 |               |                     |                     | | Italian             |
 |               |                     |                     | | Japanese            |
-|               |                     |                     | | Korean              |
 |               |                     |                     | | Portuguese - Brazil |
 |               |                     |                     | | Portuguese - Europe |
 +---------------+---------------------+---------------------+-----------------------+
@@ -110,7 +109,6 @@ Supported builtin entities
 |               |                     |                     | | French              |
 |               |                     |                     | | Italian             |
 |               |                     |                     | | Japanese            |
-|               |                     |                     | | Korean              |
 |               |                     |                     | | Portuguese - Brazil |
 |               |                     |                     | | Portuguese - Europe |
 +---------------+---------------------+---------------------+-----------------------+
@@ -120,7 +118,6 @@ Supported builtin entities
 |               |                     |                     | | French              |
 |               |                     |                     | | Italian             |
 |               |                     |                     | | Japanese            |
-|               |                     |                     | | Korean              |
 |               |                     |                     | | Portuguese - Brazil |
 |               |                     |                     | | Portuguese - Europe |
 +---------------+---------------------+---------------------+-----------------------+


### PR DESCRIPTION
As the `README.rst` is produced by the `build.rs` script of `snips-nlu-ontology-doc`, we must ensure that it is correctly commited whenever there is a change.