### PR TITLE
Release 0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.66.0]
 ### Changed
 - Remove support for music entities in korean [#148](https://github.com/snipsco/snips-nlu-ontology/pull/148)
 - Remove snips-nlu-ontology-export kotlin package [#149](https://github.com/snipsco/snips-nlu-ontology/pull/149)
@@ -190,7 +190,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated Rustling ontology to `0.16.4`
 
-[Unreleased]: https://github.com/snipsco/snips-nlu-ontology/compare/0.65.0...HEAD
+[0.66.0]: https://github.com/snipsco/snips-nlu-ontology/compare/0.65.0...0.66.0
 [0.65.0]: https://github.com/snipsco/snips-nlu-ontology/compare/0.64.8...0.65.0
 [0.64.8]: https://github.com/snipsco/snips-nlu-ontology/compare/0.64.7...0.64.8
 [0.64.7]: https://github.com/snipsco/snips-nlu-ontology/compare/0.64.6...0.64.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.66.0]
 ### Changed
+- Remove references to entity parsing [#151](https://github.com/snipsco/snips-nlu-ontology/pull/151)
 - Remove support for music entities in korean [#148](https://github.com/snipsco/snips-nlu-ontology/pull/148)
 - Remove snips-nlu-ontology-export kotlin package [#149](https://github.com/snipsco/snips-nlu-ontology/pull/149)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology"
-version = "0.66.0-SNAPSHOT"
+version = "0.66.0"
 authors = [
     "Adrien Ball <adrien.ball@snips.ai>",
     "Thibaut Lorrain <thibaut.lorrain@snips.ai>",

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-doc"
-version = "0.66.0-SNAPSHOT"
+version = "0.66.0"
 authors = ["Adrien Ball <adrien.ball@snips.ai>"]
 edition = "2018"
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-ffi"
-version = "0.66.0-SNAPSHOT"
+version = "0.66.0"
 authors = ["Kevin Lefevre <kevin.lefevre@snips.ai>"]
 edition = "2018"
 

--- a/ffi/ffi-macros/Cargo.toml
+++ b/ffi/ffi-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snips-nlu-ontology-ffi-macros"
-version = "0.66.0-SNAPSHOT"
+version = "0.66.0"
 authors = [
     "Kevin Lefevre <kevin.lefevre@snips.ai>",
     "Thibaut Lorrain <thibaut.lorrain@snips.ai>",

--- a/platforms/kotlin/build.gradle
+++ b/platforms/kotlin/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 }
 
-version = "0.66.0-SNAPSHOT"
+version = "0.66.0"
 group = "ai.snips"
 
 


### PR DESCRIPTION
### Changed
- Remove references to entity parsing [#151](https://github.com/snipsco/snips-nlu-ontology/pull/151)
- Remove support for music entities in korean [#148](https://github.com/snipsco/snips-nlu-ontology/pull/148)
- Remove snips-nlu-ontology-export kotlin package [#149](https://github.com/snipsco/snips-nlu-ontology/pull/149)